### PR TITLE
BREAKING CHANGE: removal of transitions from compiled regex type

### DIFF
--- a/src/Types.mo
+++ b/src/Types.mo
@@ -142,7 +142,6 @@ module{
 
   public type CompiledRegex = {
     states : [State];
-    transitions : [Transition];
     transitionTable : [[Transition]];
     startState : State;
     acceptStates : [State];


### PR DESCRIPTION
Removal of the transitions array from the compiled regex type.